### PR TITLE
Allows for more flexible requests with params

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "avametix/directapi",
     "type": "library",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "An API wrapper for the DirectAdmin API",
     "keywords": [
         "directadmin",


### PR DESCRIPTION
Allows for more control over API requests with the addition of url params alongside data, and a self-set prefix to not only allow CMD_API_ commands but any command one may need.